### PR TITLE
Fix unitialized value which prevents meditations from solving

### DIFF
--- a/src/items/Meditation.cc
+++ b/src/items/Meditation.cc
@@ -27,7 +27,7 @@ namespace enigma {
 
     Meditation::Meditation(int initState) {
         state = initState;
-        //whiteball = NULL;
+        whiteball = NULL;
     }
 
     std::string Meditation::getClass() const {


### PR DESCRIPTION
Followup to commit d6afe69db397a53efaa4e7ff5b1d8fe02d9972bb, which have not properly fixed the problem, which is easily reproducible on FreeBSD/clang.
