### PR TITLE
Value.cc: Remove invalid bool and pointer conversions to double

### DIFF
--- a/src/Value.cc
+++ b/src/Value.cc
@@ -145,10 +145,10 @@ namespace enigma {
                 val.str[0] = 0;
                 break;
             case BOOL :
-                val.dval[0] = false;
+                val.dval[0] = 0;
                 break;
             case OBJECT :
-                val.dval[0] = (double) NULL;
+                val.dval[0] = 0;
                 break;
             case NAMEDOBJECT:
                 ASSERT(false, XLevelRuntime, "Value: illegal type usage");


### PR DESCRIPTION
I found a few instances of bugs in the engima sources which broke compilation with a C++11 compiler, mainly related to illegal conversions.  Patches attached.

This occurred when building with Xerces-C 3.2.0 with C++11 support for char16_t strings enabled.