### PR TITLE
Define $CONVERT to fix "density: command not found" error

### DIFF
--- a/doc/reference/images/Makefile.am
+++ b/doc/reference/images/Makefile.am
@@ -1,6 +1,7 @@
 
 PNG = first_level.png construction.png ralD006_1.png
 
+CONVERT=convert
 CONVERTOPT = -density 112x112 -units PixelsPerCentimeter
 
 # Enable out of source build


### PR DESCRIPTION
Defines `CONVERT=convert` in doc/reference/images/Makefile.am to fix `density: command not found` error that happens without defining `$(CONVERT)`.

The build rule was running `$(CONVERT) $(CONVERTOPT) ...` but CONVERT wasn't defined anywhere, so this caused make to try to run the command `density` (part of the CONVERTOPT variable) instead of `convert`. The `density` command wasn't found, of course.

A leading dash causes errors to be ignored [1] so `-density` in CONVERTOPT variable was interpreted as running the `density` command and to ignore the error.

1. https://stackoverflow.com/a/2670143/

2. Build errors: https://gist.github.com/Quipyowert2/c46111280074a4ccddb1046a64d74245