### PR TITLE
Fix locale dir

### DIFF
--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -25,7 +25,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 datarootdir = @datarootdir@
 datadir = @datadir@
-localedir = $(datadir)/locale
+localedir = @localedir@
 gettextsrcdir = $(datadir)/gettext/po
 
 INSTALL = @INSTALL@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -441,7 +441,7 @@ if MINGW32
 
 else # not MINGW32
 
-  localedir_enigma := $(datadir)/locale
+  localedir_enigma := @localedir@
   mingw_ldadd =
 
 endif


### PR DESCRIPTION
`@localedir@` is a standard autotools substitution.

This way, it'll respect the `--localedir=/path` configure option.