### PR TITLE
Clear indexGroups just before exiting to fix leak.

### DIFF
--- a/src/lev/Index.cc
+++ b/src/lev/Index.cc
@@ -47,6 +47,12 @@ namespace enigma { namespace lev {
         }
         currentGroup = app.state->getString("CurrentGroup");
     }
+    void Index::shutdown()
+    {
+        for (auto it = indexGroups.begin();it != indexGroups.end();it++) {
+            delete it->second;
+        }
+    }
     
     void Index::registerIndex(Index *anIndex) {
         if (anIndex == NULL)

--- a/src/lev/Index.hh
+++ b/src/lev/Index.hh
@@ -68,6 +68,7 @@ namespace enigma { namespace lev {
     class Index  {
     public:
         static void initGroups();
+        static void shutdown();
         static void registerIndex(Index *anIndex);
         static Index * findIndex(std::string anIndexName);
         static Index * getCurrentIndex();

--- a/src/main.cc
+++ b/src/main.cc
@@ -904,6 +904,7 @@ void Application::shutdown()
         lev::ScoreManager::instance()->shutdown();
         app.state->shutdown();
         app.prefs->shutdown();
+        lev::Index::shutdown();
     }
     // now we shutdown SDL - no error reports will be possible!
     app.errorInit = false;


### PR DESCRIPTION
Valgrind reported a leak in `Index::initGroups()`. When I checked whether the pointers in the `indexGroups` vector were being deleted, it doesn't seem to be deleted anywhere, just like Valgrind says. This pull request remedies this by adding a new method ~~`deleteGroups()`~~ `lev::Index::shutdown()` which deletes the `second` pointer of each pair, and having it be called from `Application::shutdown()`.

The relevant leak from `valgrind --undef-value-errors=no --leak-check=full --show-leak-kinds=definite src/enigma`
```
==8358== 1,775,898 (192 direct, 1,775,706 indirect) bytes in 8 blocks are definitely lost in loss record 1,897 of 1,900
==8358==    at 0x4C2E91F: operator new(unsigned long) (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==8358==    by 0x502151: enigma::lev::Index::initGroups() (Index.cc:45)
==8358==    by 0x461F01: enigma::Application::init(int, char**) (main.cc:442)
==8358==    by 0x40F476: main (main.cc:928)
==8358== 
==8358== LEAK SUMMARY:
==8358==    definitely lost: 1,871 bytes in 76 blocks
==8358==    indirectly lost: 2,106,218 bytes in 11,294 blocks
==8358==      possibly lost: 21,235,278 bytes in 6,078 blocks
==8358==    still reachable: 2,709,501 bytes in 28,999 blocks
==8358==                       of which reachable via heuristic:
==8358==                         multipleinheritance: 288 bytes in 12 blocks
==8358==         suppressed: 0 bytes in 0 blocks
==8358== Reachable blocks (those to which a pointer was found) are not shown.
==8358== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==8358== 
==8358== For counts of detected and suppressed errors, rerun with: -v
==8358== ERROR SUMMARY: 915 errors from 915 contexts (suppressed: 0 from 0)
```