### PR TITLE
Update macOS build process for easy build in Homebrew and easy preparation of macOS release bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Makefile.in
 doc/reference/images/*.png
 lib-src/enet/compile
 lib-src/zipios++/compile
+.DS_STORE

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,10 +35,6 @@ macapp:
 macpreview:
 	cd src && $(MAKE) $(AM_MAKEFLAGS) bundle-preview
 
-.PHONY: macdmg
-macdmg:
-	cd src && $(MAKE) $(AM_MAKEFLAGS) bundle-dmg
-
 .PHONY: pdf
 pdf:
 	cd doc/manual/images && $(MAKE) pdf

--- a/configure.ac
+++ b/configure.ac
@@ -41,21 +41,16 @@ AM_CONDITIONAL(MINGW32, test x$MINGW32 = xyes)
 AM_CONDITIONAL(LINUX, test x$LINUX = xyes)
 
 dnl ----------------------------------------
+dnl This comment block is obsolete, but leaving it in until I or someone figures out if the script lines after can simply be removed.
+dnl  now that nothing needs to be done to try for a static link. Maybe we don't even need the with-linitl-prefix option anymore?
 dnl Mac requires libintl to be linked statically and doesn't make that easy
 dnl gettext project (for libintl) refuses to support use of pkg-config but doesn't provide an
 dnl equivalent way to get the lib directory it is installed in. This requires use of --with-libintl-prefix configure option.
 dnl ---------------------------------------
 if test "x$MACOSX" = xyes; then
   LIBS="$LIBS_NOGETTEXT"
-  if test -z "$with_libintl_prefix" ; then
-    AC_MSG_ERROR([On MacOS --with-libintl-prefix must be specified to find lib/libintl.a for static link])
-  fi
-  if test -d "${with_libintl_prefix}/lib" && test -f "${with_libintl_prefix}/lib/libintl.a" ; then
-    LIBINTL="${with_libintl_prefix}/lib/libintl.a"
-    LIBS="$LIBINTL /usr/lib/libiconv.dylib $LIBS"
-  else
-    AC_MSG_ERROR([The specified --with-libintl-prefix did not contain lib/libintl.a which is required on MacOS for static link])
-  fi
+  LIBINTL="-lintl"
+  LIBS="$LIBINTL /usr/lib/libiconv.dylib $LIBS"
 fi
 
 dnl ======================================================================
@@ -156,13 +151,10 @@ SDL_LIBS="$SDL_LIBS -lSDL2_mixer"
 AC_CHECK_LIB(SDL2_ttf, main,,[AC_MSG_ERROR([SDL2_ttf is required to compile Enigma])])
 SDL_LIBS="$SDL_LIBS -lSDL2_ttf"
 
-dnl Add special hack for Mac framework SDL after all other SDL stuff has been done
-dnl Note that SDL development environment must be installed for the build but SDL frameworks must also be installed for the build
-dnl If we had libSDLmain.a, which is not included in the framework, we should be able to get away with only installing framework
 if test "x$MACOSX" = xyes; then
- SDL_STATIC_PREFIX=`$SDL2_CONFIG $sdl2_config_args --prefix`
- SDL_LIBS="-Wl,-rpath,@loader_path/../Frameworks -framework AudioToolbox -framework AudioUnit -framework Cocoa -framework CoreAudio -framework IOKit -framework CoreFoundation -framework Carbon -framework CoreServices -framework ApplicationServices -framework Foundation -framework AppKit -framework OpenGL -framework SDL2 -framework SDL2_mixer -framework SDL2_image -framework SDL2_ttf $SDL2_STATIC_PREFIX/lib/libSDL2main.a"
-AC_SUBST(SDL2_STATIC_PREFIX)
+ SDL2_PREFIX=`$SDL2_CONFIG $sdl2_config_args --variable=libdir`
+ SDL_LIBS="-Wl,-rpath,@loader_path/../lib -framework AudioToolbox -framework AudioUnit -framework Cocoa -framework CoreAudio -framework IOKit -framework CoreFoundation -framework Carbon -framework CoreServices -framework ApplicationServices -framework Foundation -framework AppKit -framework OpenGL -lSDL2 -lSDL2_mixer -lSDL2_image -lSDL2_ttf $SDL2_PREFIX/libSDL2main.a"
+AC_SUBST(SDL2_PREFIX)
 fi
 
 dnl ---------------------------------------
@@ -213,20 +205,11 @@ else
 fi
 
 dnl ----------------------------------------
-dnl Mac requires libintl, libpng, freetype  and xerces-c to be linked statically and doesn't make that easy
-dnl Handle it by reverting to LIBS before the AC_CHECK_LIBS of png and xerces-c and prepending the static libs
-dnl pkg-config is not convenient to use. This works around in a bug currently in freetype2.pc that puts in extra quotes
+dnl On Mac SDL flags are set up differently. This is a bit of a kludge for it
 dnl ---------------------------------------
 if test "x$MACOSX" = xyes; then
-  if test -z "$with_libintl_prefix" ; then
-    AC_MSG_ERROR([On MacOS --with-libintl-prefix must be specified to find lib/libintl.a for static link])
-  fi
   CFLAGS="$CFLAGS_NOSDL"
   CXXFLAGS="$CXXFLAGS_NOSDL"
-  FREETYPE_PREFIX=`$PKG_CONFIG freetype2 --variable libdir`
-  PNG_PREFIX=`$PKG_CONFIG libpng --variable libdir`
-  XERCESC_PREFIX=`$PKG_CONFIG xerces-c --variable libdir`
-  LIBS="-lz -lbz2 ${FREETYPE_PREFIX//\"/}/libfreetype.a ${PNG_PREFIX//\"/}/libpng.a ${XERCESC_PREFIX//\"/}/libxerces-c.a $LIBS_NOSDL"
 fi
 
 dnl ----------------------------------------

--- a/doc/README.macosx
+++ b/doc/README.macosx
@@ -1,80 +1,92 @@
-Building Enigma under MacOS X 10.6 through 10.10
+Building Enigma under MacOS X
+=============================
 
-Overview:
----------
-
-Due to which machines are available to Enigma developers, the latest
-version of Enigma has only been built on 64-bit Intel Macs running
-Snow Leopard (10.6) and later.
+The development and build processes of Enigma are dependent on libraries
+packaged by the Homebrew project. As Homebrew only supports versions of MacOS
+that are supported by Apple, Enigma may not run on any particular version of
+MacOS that has passed Apple's end of support date. A list of versions and dates
+can be found in the Wikipedia entry for "macOS version history".
 
 The build process has been simplified compared to earlier versions of
 Enigma by having it run under Homebrew.
 
-To install Homebrew, you will need to first install either Xcode or
-the Xcode Command Line Tools, then install Homebrew.
+Documentation on installing Homebrew can be found at https://docs.brew.sh/Installation
 
-Complete documentation on Homebrew is in their wiki, whose link can be
-found just below the installation instructions on their web site home
-http://brew.sh
+A summary of the steps required (but see the above site for details):
 
-After installing Xcode or the Command Line Tools, enter the following
-command line in Terminal to install Homebrew:
-
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+1. First install either Xcode or the Xcode Command Line Tools or both if you prefer.
+2. Run the one line command shown on the Homebreqw home page https://brew.sh
 
 Then follow the instructions to have Homebrew installed in just a few minutes.
 Be sure to run brew doctor as it advises you to, and correct any problems
 that it discovers with your configuration.
 
-You also need to install four framework packages from the SDL project. The frameworks
-are required to build enigma, but do not have to be installed by end-users as the
-necessary framework files will be bundled with the Enigma application.
+Once Homebrew is installed, run the command
 
-On each of the following pages you will find a download link labeled for Mac OS X Intel 10.5+
-Download the dmg file at the link, open it, and drag the folder named, for example,
-SDL.framework,  into /Library/Frameworks/
+  brew install -v enigma
 
-https://www.libsdl.org/download-1.2.php
-https://www.libsdl.org/projects/SDL_image/release-1.2.html
-https://www.libsdl.org/projects/SDL_mixer/release-1.2.html
-https://www.libsdl.org/projects/SDL_ttf/release-1.2.html
+The "-v" is optional. It only makes the process more verbose to let you see the progress
+of the installation and possible problems if they occur.
 
-If you have done this correctly, /Library/Frameworks will have added to it folders named
+This command will usually download pre-built binaries from Homebrew's build servers, if
+they are available, built from the same sources and for the same version of MacOS that
+you are running. Otherwise it will download the source tree and build on your computer.
 
-SDL.framework
-SDL_image.framework
-SDL_mixer.framework
-SDL_ttf.framework
+After the installation is complete you will have a folder named /usr/local/opt/enigma/Enigma.
+Drag the entire folder into /Applications. It contains the Enigma.app application that you can run,
+and the Enigma documentation manual that you can open to read in your web browser.
 
-Once Homebrew and the SDL frameworks are installed, download the file enigma-game.rb from
-the Enigma web site and place it in directory /usr/local/Library/Formula/
-which is where the Homebrew formula files are stored.
+Building the latest development snapshot or from a forked repo
+==============================================================
 
-Then to build Enigma run the command
+To build the latest development snapshot from GitHub repo source, use the options
 
- brew -v install enigma-game
-
-That will download, build, and install all the prerequisites and if all
-goes well will create the file /usr/local/share/enigma.dmg
-
-Build Options:
-
-Type the command
-
- brew options enigma-game
-
-to see the options that are available for the build.
-
-To build the latest development snapshot, use the option --HEAD
-
-To construct the level preview images at build time and store them in the application bundle so
-that user's computer does not have to build each one the first time each level is run, use the
-option --make-preview. This option will take some time to run as it generates each level image.
-
-For example, to build the development version and include the previews, run the command
-
- brew -v install enigma-game --HEAD --make-preview
+  brew install -v -s --HEAD enigma
 
 To build Enigma again, for example to build it with a different set of options, first run the command
 
- brew remove enigma-game
+ brew remove enigma
+
+To have --HEAD build from a different git repo, for example when you are a developer, edit your local
+copy of the Homebrew formula by running the command
+
+ brew edit enigma
+
+and change the URL in the head section to link to the repo you want to use.
+See https://docs.brew.sh/Formula-Cookbook#unstable-versions-head for more details.
+
+
+Building an Enigma application that can be run outside of a Homebrew environment
+================================================================================
+
+The above instructions result in a copy of Enigma.app that requires the Homebrew environment to run.
+To make an Enigma.app that can be run on macOS without Homebrew installed, perform the following steps.
+
+Note that the resulting build may experience problems running on an older version of macOS than it
+was built on. For the best assurance of compatibilty on other systems, build Enigma on the oldest version
+of macOS that is currently supported by Apple.
+
+To prepare your Homebrew environment for running this procedure, install packages with the command
+
+  brew install -v imagemagick fileicon create-dmg dylibbundler
+
+Then from the Enigma source repository on GitHub get the file makedmgforenigma.sh in the etc directory.
+The direct download link for the file from the master branch on GitHub is
+https://raw.githubusercontent.com/Enigma-Game/Enigma/master/etc/makedmgforenigma.sh
+
+Place the file in a suitable place on your computer, for example in a directory named ~/bin or anywhere
+convenient. Make the file executable with a command such as
+
+  chmod +x ~/bin/makedmgforenigma.sh
+
+If you have not already, install Enigma
+
+  brew install -v enigma
+
+Then in the directory in which you will create the distribution dmg file, run the command using for example
+
+  ~/bin/makedmgforenigma.sh
+
+This will read the copy of Enigma that Homebrew installed in /usr/local/opt/enigma/Enigma and
+create a file in the current directory named Enigma.dmg. That file can be cpoied to a suitable
+macOS computer where it can be opened to install an Enigma folder in /Applications.

--- a/etc/makedmgforenigma.sh
+++ b/etc/makedmgforenigma.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Script used on a Mac as part of the Enigma release process.
+# Run this on a machine that has Enigma installed by Hombrew to create a dmg suitable for distribution.
+
+# Fixes up the library dependencies in the Enigma application bundle that has been installed by Homebrew
+# and creates a Enigma.dmg file in the current directory suitable for distribution to systems without Homebrew
+# Generates a few warnings if the application bundle has already been fixed up, but doesn't break it
+# If there is an existing Enigma.dmg file in the current directory it will be deleted and a new one created
+# Result is a file Enigma.dmg in the directory that is current when this is run.
+
+# Note that this is taking a lazy way to do the graphics by taking an existing image file from doc/image directory
+# that happens to be suitable. If anyone ever changes or removes that file, this will have to be changed
+
+# check for required utilities that can be installed using brew
+hash convert 2>/dev/null  || { echo >&2 "This script requires ImageMagick convert but it's not installed. Install imagemagick from homebrew. Aborting."; exit 1; }
+for foo in fileicon create-dmg dylibbundler ; do
+    hash $foo 2>/dev/null || { echo >&2 "This script requires $foo but it's not installed. Install it from homebrew. Aborting."; exit 1; }
+done
+
+DEST=/tmp/Enigma_temp_dist_build
+DMG_FILE_NAME="Enigma.dmg"
+ENIGMA_APP_DIR=`brew --prefix enigma`
+ENIGMA_FOLDER="$ENIGMA_APP_DIR/Enigma"
+ENIGMA_APP_PATH="$DEST/Enigma/Enigma.app"
+BACKGROUND_IMAGE="$ENIGMA_APP_PATH/Contents/Resources/doc/images/menu_bg.jpg"
+MESSAGE_IN_FILE_NAME1=".dummy1"
+MESSAGE_IN_FILE_NAME2=".dummy2"
+
+if [ -z "$ENIGMA_APP_DIR" ]; then
+    echo "Error: No enigma installed"
+    exit 1
+fi
+
+if [ ! -d "$ENIGMA_APP_DIR" ]; then
+    echo "Error: No installed directory '$ENIGMA_APP_DIR'"
+    exit 1
+fi
+
+if [ ! -d "$ENIGMA_FOLDER" ]; then
+    echo "Error: No container directory '$ENIGMA_FOLDER'"
+    exit 1
+fi
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp -a "$ENIGMA_FOLDER" "$DEST/"
+
+if [ ! -d "$ENIGMA_APP_PATH" ]; then
+    echo "Error: No application path '$ENIGMA_APP_PATH'"
+    exit 1
+fi
+
+if [ ! -f "$BACKGROUND_IMAGE" ]; then
+    echo "Error: No background image file '$BACKGROUND_IMAGE'"
+    exit 1
+fi
+
+
+# if dylibbundler doesn't work right, take a look at github.com/chearon/macpack
+# setting DYLD_LIBRARY_PATH and the -i option allows this to be run more than once on the same file, with only a few warnings as a result
+DYLD_LIBRARY_PATH="$ENIGMA_APP_PATH/Contents/lib" dylibbundler -cd -x $ENIGMA_APP_PATH/Contents/MacOS/enigma -b -i $ENIGMA_APP_PATH/Contents/lib/ -d $ENIGMA_APP_PATH/Contents/lib/ -p @executable_path/../lib/
+
+# Create some files on the fly that will be used to put a message on the dmg folder
+rm -f "$DMG_FILE_NAME"
+touch "$DEST/$MESSAGE_IN_FILE_NAME1"
+touch "$DEST/$MESSAGE_IN_FILE_NAME2"
+convert -size 16x16 xc:transparent "$DEST/transparent.ico"
+fileicon set "$DEST/$MESSAGE_IN_FILE_NAME1" "$DEST/transparent.ico"
+fileicon set "$DEST/$MESSAGE_IN_FILE_NAME2" "$DEST/transparent.ico"
+
+create-dmg --no-internet-enable --volname Enigma --background "$BACKGROUND_IMAGE" --window-pos 50 60 --window-size 400 320 --icon-size 50 --icon "Enigma" 20 50 --app-drop-link 200 50 --add-file "Enigma folder contains app and manual" "$DEST/$MESSAGE_IN_FILE_NAME1" 10 130 --add-file "Drag it to Applications to install" "$DEST/$MESSAGE_IN_FILE_NAME2" 200 130 --text-size 14 "$DMG_FILE_NAME" "$DEST"
+
+rm -rf "$DEST"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -544,10 +544,6 @@ bundle:
 .PHONY: bundle-fw
 bundle-fw:
 	cp enigma $(bundle_name)/Contents/MacOS/enigma
-	mkdir  $(bundle_name)/Contents/Frameworks
-	for i in SDL SDL_mixer SDL_image SDL_ttf ; do \
-	  cp -a /Library/Frameworks/$${i}.framework $(bundle_name)/Contents/Frameworks/; \
-	done
 	strip $(bundle_name)/Contents/MacOS/enigma
 
 # Special target to create the preview images into the app bundle
@@ -590,9 +586,3 @@ bundle-doc:
 	cp $(top_builddir)/doc/manual/*.html $(bundle_doc)/manual/
 	cp $(top_builddir)/doc/reference/images/*.png $(bundle_doc)/reference/images/
 	cp $(top_builddir)/doc/reference/*.html $(bundle_doc)/reference/
-
-# Special target to make a disk image of the bundled app
-.PHONY: bundle-dmg
-bundle-dmg:
-	hdiutil create  -ov -srcfolder $(bundle_root) -volname Enigma -imagekey zlib-level=6 $(top_builddir)/etc/enigma.dmg
-


### PR DESCRIPTION
Remove everything in build for macOS to do with trying for static links or bundling dylibs with app, or creating dmg.
Add new shell script to bundle dylibs with app and create dmg to be run separately for release process.
Update macOS build readme.
Add .DS_STORE to .gitignore
