### PR TITLE
added working 1080p , WQHD and UHD(4k) resolution for fullscreen and windowed

### DIFF
--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Enigma 1.21\n"
-"Report-Msgid-Bugs-To: enigma-devel@nongnu.org\n"
+"Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-10-09 22:56+0200\n"
 "PO-Revision-Date: 2018-05-01 13:45+0000\n"
 "Last-Translator: Michał Trzebiatowski <michtrz@gmail.com>\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Enigma 1.21\n"
-"Report-Msgid-Bugs-To: enigma-devel@nongnu.org\n"
+"Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-10-09 22:56+0200\n"
 "PO-Revision-Date: 2018-04-30 23:39+0000\n"
 "Last-Translator: fri\n"

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Enigma 1.21\n"
-"Report-Msgid-Bugs-To: enigma-devel@nongnu.org\n"
+"Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-10-09 22:56+0200\n"
 "PO-Revision-Date: 2018-04-30 23:39+0000\n"
 "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"

--- a/src/video.cc
+++ b/src/video.cc
@@ -378,6 +378,60 @@ VMInfo video_modes[] = {
      0,                             // statusbar coffsety
      false,                         // available fullscreen
      "-9-0-"                        // fallback modes fullscreen
+    },
+    {
+     VM_1920x1080, 6, 1920, 1080,     // id, preffilenr, w, h
+     64, VTS_64,                    // tilesize, tiletype
+     "1920x1080", "FHD", "16:9", // name, fsname, fs only
+     Rect(0, 0, 1920, 1080),         // display area
+     -400, -90,                     // menu background image offsets
+     {160, 104, 5, "-160x104"},     // thumbnail size/extension
+     Rect(0, 0, 1920, 832),         // game area
+     Rect(0, 832, 1920, 128),       // statusbar area
+     Rect(24, 857, 227, 80),        // time area //TODO
+     Rect(204, 853, 40, 80),        // modes area //TODO
+     Rect(204, 853, 40, 80),        // moves area //TODO
+     Rect(376, 867, 947, 61),       // inventory area //TODO
+     Rect(360, 884, 888, 53),       // text area //TODO
+     1,                             // statusbar coffsety
+     true,                          // available fullscreen
+     "-6-4-2-0-"                    // fallback modes fullscreen
+    },
+    {
+     VM_2560x1440, 6, 2560, 1440,     // id, preffilenr, w, h
+     64, VTS_64,                    // tilesize, tiletype
+     "2560x1440", "WQHD", "16:9", // name, fsname, fs only
+     Rect(0, 0, 2560, 1440),         // display area
+     -400, -90,                     // menu background image offsets
+     {160, 104, 5, "-160x104"},     // thumbnail size/extension
+     Rect(0, 0, 2560, 832),         // game area
+     Rect(0, 832, 2560, 128),       // statusbar area
+     Rect(24, 857, 227, 80),        // time area //TODO
+     Rect(204, 853, 40, 80),        // modes area //TODO
+     Rect(204, 853, 40, 80),        // moves area //TODO
+     Rect(376, 867, 947, 61),       // inventory area //TODO
+     Rect(360, 884, 888, 53),       // text area //TODO
+     1,                             // statusbar coffsety
+     true,                          // available fullscreen
+     "-6-4-2-0-"                    // fallback modes fullscreen
+    },
+    {
+     VM_3840x2160, 6, 3840, 2160,     // id, preffilenr, w, h
+     64, VTS_64,                    // tilesize, tiletype
+     "3840x2160", "UHD", "16:9", // name, fsname, fs only
+     Rect(0, 0, 3840, 2160),         // display area
+     -400, -90,                     // menu background image offsets
+     {160, 104, 5, "-160x104"},     // thumbnail size/extension
+     Rect(0, 0, 3840, 832),         // game area
+     Rect(0, 832, 3840, 128),       // statusbar area
+     Rect(24, 857, 227, 80),        // time area //TODO
+     Rect(204, 853, 40, 80),        // modes area //TODO
+     Rect(204, 853, 40, 80),        // moves area //TODO
+     Rect(376, 867, 947, 61),       // inventory area //TODO
+     Rect(360, 884, 888, 53),       // text area //TODO
+     1,                             // statusbar coffsety
+     true,                          // available fullscreen
+     "-6-4-2-0-"                    // fallback modes fullscreen
     }
 };
 

--- a/src/video.hh
+++ b/src/video.hh
@@ -41,9 +41,12 @@ enum FullscreenMode {
     VM_1280x960 = 7,   ///< 64x64 basic    -  4:3  - none
     VM_1280x1024 = 8,  ///< 64x64 embedded -  5:4  - SXGA
     VM_1440x960 = 9,   ///< 64x64 embedded -  3:2  - none
-    VM_1680x1050 = 10,  ///< 64x64 embedded - 16:10 - WSXGA+
-    VM_LAST = 10,
-    VM_COUNT = 11
+    VM_1680x1050 = 10, ///< 64x64 embedded - 16:10 - WSXGA+
+    VM_1920x1080 = 11, ///< 64x64 embedded - 16:9  - FHD
+    VM_2560x1440 = 12, ///< 64x64 embedded - 16:9  - WQHD
+    VM_3840x2160 = 13, ///< 64x64 embedded - 16:9  - UHD
+    VM_LAST = 13,
+    VM_COUNT = 14
 };
 
 struct WindowSize {


### PR DESCRIPTION
Hi, i added working fullscreen (and windowed) for enigma for 1080p (1920x1080) WQHD (2560 x 1440) and 4k (3840 × 2160)

Issues:
-> the game looks kinda pixelated
-> when exiting the game in fullscreen, the game starts in windowed again.

