### PR TITLE
Invalid pointer access

### DIFF
--- a/etc/enigma.desktop
+++ b/etc/enigma.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.30
+Version=1.3
 Name=Enigma
 Name[be]=Enigma
 Name[cs]=Enigma
@@ -44,5 +44,5 @@ Terminal=false
 StartupNotify=false
 Icon=enigma
 Type=Application
-Categories=Application;Game;PuzzleGame;
+X-Categories=Application;Game;PuzzleGame;
 

--- a/lib-src/zipios++/zipios++/zipheadio.h
+++ b/lib-src/zipios++/zipios++/zipheadio.h
@@ -150,7 +150,7 @@ inline void readByteSeq ( istream &is, vector < unsigned char > &vec, int count 
 }
 
 inline void writeByteSeq ( ostream &os, const vector < unsigned char > &vec ) {
-  os.rdbuf()->sputn( reinterpret_cast< const char * >( &( vec[ 0 ] ) ), vec.size() ) ;
+  os.rdbuf()->sputn( reinterpret_cast< const char * >( vec.data() ), vec.size() ) ;
 }
 
 istream& operator>> ( istream &is, ZipLocalEntry &zlh         ) ;


### PR DESCRIPTION
Hi,

I'm currently tried to create a flatpak distribution of your game and have got  an error during runtime. After finishing a level and close the application, the game fails with a SIGABRT signal. The stack trace show:
```
/usr/include/c++/10.2.0/bits/stl_vector.h:1063: std::vector<_Tp, _Alloc>::const_reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) const [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc>::const_reference = const unsigned char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.

Thread 1 "enigma" received signal SIGABRT, Aborted.
0x00007ffff74917f5 in raise () from /usr/lib/x86_64-linux-gnu/libc.so.6
(gdb) backtrace
#0  0x00007ffff74917f5 in raise () from /usr/lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff747a855 in abort () from /usr/lib/x86_64-linux-gnu/libc.so.6
#2  0x00005555557d5835 in std::__replacement_assert (__condition=0x5555557efdd8 "__builtin_expect(__n < this->size(), true)", 
    __function=0x5555557fa320 "std::vector<_Tp, _Alloc>::const_reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) const [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector"..., __line=1063, 
    __file=0x5555557eff68 "/usr/include/c++/10.2.0/bits/stl_vector.h")
    at /usr/include/c++/10.2.0/x86_64-unknown-linux-gnu/bits/c++config.h:457
#3  std::vector<unsigned char, std::allocator<unsigned char> >::operator[] (this=<optimized out>, __n=0)
    at /usr/include/c++/10.2.0/bits/stl_vector.h:1063
#4  std::vector<unsigned char, std::allocator<unsigned char> >::operator[] (__n=0, this=<optimized out>)
    at /usr/include/c++/10.2.0/bits/stl_vector.h:1061
#5  zipios::writeByteSeq (vec=std::vector of length 0, capacity 0, vec=std::vector of length 0, capacity 0, os=...)
    at ./../zipios++/zipheadio.h:153
#6  zipios::operator<< (os=..., zlh=...) at zipheadio.cpp:114
#7  0x00005555557d8938 in zipios::ZipOutputStreambuf::putNextEntry (this=this@entry=0x7fffffffc340, entry=...)
    at zipoutputstreambuf.cpp:77
#8  0x0000555555626fe9 in enigma::writeToZip (zipStream=..., filename="score.xml", size=size@entry=1512, contents=...)
    at file_zip.cc:67
#9  0x000055555573d4be in enigma::lev::ScoreManager::save (this=0x55555838e8d0) at lev/ScoreManager.cc:460
#10 0x0000555555606dd1 in enigma::client::Client::level_finished (
    this=0x55555592eb60 <enigma::client::(anonymous namespace)::client_instance>) at client.cc:810
#11 0x00005555556072b3 in enigma::client::Msg_Command (cmd=...) at client.cc:937
#12 0x0000555555679bb7 in enigma::server::Tick (dtime=dtime@entry=0.01) at server.cc:368
#13 0x0000555555629d81 in enigma::game::StartGame () at game.cc:83
#14 0x00005555556ca85d in enigma::gui::LevelMenu::on_action (this=0x7fffffffd2d0, w=<optimized out>) at gui/LevelMenu.cc:281
#15 0x00005555556dc98a in enigma::gui::LevelWidget::trigger_action (this=this@entry=0x555555f45990) at gui/LevelWidget.cc:104
#16 0x00005555556de8c8 in enigma::gui::LevelWidget::handle_mousedown (this=0x555555f45990, e=<optimized out>)
    at gui/LevelWidget.cc:462
#17 0x00005555556decc6 in enigma::gui::LevelWidget::on_event (this=0x555555f45990, e=...) at gui/LevelWidget.cc:424
#18 0x00005555556e6950 in enigma::gui::Menu::handle_event (this=this@entry=0x7fffffffd2d0, e=...) at gui/Menu.cc:169
#19 0x00005555556e6c83 in enigma::gui::Menu::manage (this=this@entry=0x7fffffffd2d0) at gui/Menu.cc:96
--Type <RET> for more, q to quit, c to continue without paging--
#20 0x00005555556d8b5d in enigma::gui::LevelPackMenu::manageLevelMenu (this=this@entry=0x7fffffffd6f0) at gui/LevelPackMenu.cc:437
#21 0x00005555556e5587 in enigma::gui::MainMenu::on_action (this=0x7fffffffda70, w=<optimized out>) at gui/MainMenu.cc:559
#22 0x00005555556f305a in enigma::gui::Widget::invoke_listener (this=this@entry=0x5555580fdd30) at gui/widgets.cc:63
#23 0x00005555556f5396 in enigma::gui::PushButton::on_event (this=0x5555580fdd30, e=...) at gui/widgets.cc:756
#24 0x00005555556e6950 in enigma::gui::Menu::handle_event (this=this@entry=0x7fffffffda70, e=...) at gui/Menu.cc:169
#25 0x00005555556e6c83 in enigma::gui::Menu::manage (this=this@entry=0x7fffffffda70) at gui/Menu.cc:96
#26 0x00005555556e5369 in enigma::gui::ShowMainMenu () at gui/MainMenu.cc:623
#27 0x00005555555eddae in main (argc=<optimized out>, argv=<optimized out>) at main.cc:994
```
That error is located inside the zipios++ library. The problem is, that accessing an empty raw vector is not allowed. If you try to get the address of the array root address with the ```[]operator``` C++ try to dereference the invalid root .

Use the ```.data()```method will return the raw pointer without dereferencing.

Why the error only occurs within flatpak is unclear, because the same (wrong) code works on debian. The only guess I have is that debian is less strict during compiling and optimize out the dereferencing.  