### PR TITLE
Fix error cast HINSTANCE to int loses precision.

### DIFF
--- a/lib-src/enigma-core/ecl_system.cc
+++ b/lib-src/enigma-core/ecl_system.cc
@@ -119,7 +119,7 @@ bool ecl::FolderCreate(const std::string &fname) {
 bool ecl::BrowseUrl(const std::string url) {
     bool result = true;
 #ifdef __MINGW32__
-    result == ((int)ShellExecute(NULL, "open", url.c_str(), NULL, NULL, SW_SHOWNORMAL) >= 32);
+    result == ((INT_PTR)ShellExecute(NULL, "open", url.c_str(), NULL, NULL, SW_SHOWNORMAL) >= 32);
 #elif MACOSX
     CFStringRef cfurlStr = CFStringCreateWithCString(NULL, url.c_str(), kCFStringEncodingASCII);
 
@@ -141,7 +141,7 @@ bool ecl::BrowseUrl(const std::string url) {
 bool ecl::ExploreFolder(const std::string path) {
     bool result = true;
 #ifdef __MINGW32__
-    result == ((int)ShellExecute(NULL, "explore", path.c_str(), NULL, NULL, SW_SHOWNORMAL) >= 32);
+    result == ((INT_PTR)ShellExecute(NULL, "explore", path.c_str(), NULL, NULL, SW_SHOWNORMAL) >= 32);
 #elif MACOSX
     FSRef fref;
     FSPathMakeRef((UInt8 *)path.c_str(), &fref, NULL);


### PR DESCRIPTION
Fixes #59 by changing two int casts to INT_PTR casts. [ShellExecute return value](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea#return-value) says "it can be cast only to an INT_PTR." The cast to int was causing a compilation error saying that the cast loses precision.