### PR TITLE
Unbreak the build on modern gcc -Werror=format-security

### DIFF
--- a/src/lua.cc
+++ b/src/lua.cc
@@ -3894,14 +3894,14 @@ void CheckedDoFile (lua_State *L, GameFS * fs, std::string const& fname)
     if (!fs->findFile(fname, completefn))
     {
         fprintf(stderr, _("Cannot find '%s'.\n"), fname.c_str());
-        fprintf(stderr, _("Your installation may be incomplete or invalid.\n"));
+        fprintf(stderr, "%s", _("Your installation may be incomplete or invalid.\n"));
         exit (1);
     }
 
     lua::Error status = lua::DoAbsoluteFile(L, completefn);
     if (status != lua::NO_LUAERROR) {
         fprintf(stderr, _("There was an error loading '%s'.\n"), completefn.c_str());
-        fprintf(stderr, _("Your installation may be incomplete or invalid.\n"));
+        fprintf(stderr, "%s", _("Your installation may be incomplete or invalid.\n"));
         fprintf(stderr, _("Error: '%s'\n"), lua::LastError(L).c_str());
         exit (1);
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -352,7 +352,7 @@ void Application::init(int argc, char **argv)
 
     // initialize preferences -- needs LUA, XML
     if (!options::Load()) {
-        fprintf(stderr, _("Error in configuration file.\n"));
+        fprintf(stderr, "%s", _("Error in configuration file.\n"));
       	fprintf(stderr, "%s\n", lua::LastError (lua::GlobalState()).c_str());
     }
     prefs = PreferenceManager::instance();
@@ -593,7 +593,7 @@ void Application::initSysDatapaths(const std::string &prefFilename)
         if (!ecl::FolderExists(prefPath))
             // may happen on Windows
             if(!ecl::FolderCreate(prefPath)) {
-                fprintf(stderr, _("Error: Home directory does not exist.\n"));
+                fprintf(stderr, "%s", _("Error: Home directory does not exist.\n"));
                 exit(1);
             }
 #ifdef MACOSX
@@ -608,7 +608,7 @@ void Application::initSysDatapaths(const std::string &prefFilename)
         if (!ecl::FolderExists(winAppDataPath))
             // may happen on Windows
             if(!ecl::FolderCreate(winAppDataPath)) {
-                fprintf(stderr, _("Error: Application Data directory does not exist.\n"));
+                fprintf(stderr, "%s", _("Error: Application Data directory does not exist.\n"));
                 exit(1);
             }
 //        Log << "winAppDataPath " << winAppDataPath << "\n";
@@ -616,7 +616,7 @@ void Application::initSysDatapaths(const std::string &prefFilename)
         prefPath = winAppDataPath + ecl::PathSeparator + "." + prefFilename;
 #endif
     } else {
-        fprintf(stderr, _("Error: Home directory does not exist.\n"));
+        fprintf(stderr, "%s", _("Error: Home directory does not exist.\n"));
         exit(1);
     }
 }
@@ -635,7 +635,7 @@ void Application::initXerces() {
                 makeNewTranscoderFor(XMLRecognizer::UTF_8, initResult,
                 4096); // the block size is irrelevant for utf-8
         if (initResult != XMLTransService::Ok) {
-            fprintf(stderr, _("Error in XML initialization.\n"));
+            fprintf(stderr, "%s", _("Error in XML initialization.\n"));
             exit(1);
         }
 
@@ -684,7 +684,7 @@ void Application::initXerces() {
 #endif
     }
     catch (...) {
-        fprintf(stderr, _("Error in XML initialization.\n"));
+        fprintf(stderr, "%s", _("Error in XML initialization.\n"));
         exit(1);
     }
 }


### PR DESCRIPTION
Currently the build fails with a security warning (turned into an error) about format strings:

```
lua.cc: In function 'void enigma::lua::CheckedDoFile(lua_State*, enigma::GameFS*, const string&)':
lua.cc:3897:79: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlin
edocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
 3897 |         fprintf(stderr, _("Your installation may be incomplete or invalid.\n"));
      |                                                                               ^
lua.cc:3904:79: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
 3904 |         fprintf(stderr, _("Your installation may be incomplete or invalid.\n"));
      |                                                                               ^
cc1plus: some warnings being treated as errors
```

This pull request fixes this issue by introducing the `"%s"` desired by gcc.

Thank you for your work in maintaing Enigma! I recall having enjoyed lots of hours playing it, also with my family, when I was younger.