### PR TITLE
Fix inventory rotation via mousewheel

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -211,7 +211,7 @@ void Client::handle_events() {
         case SDL_MOUSEBUTTONUP: on_mousebutton(e); break;
         case SDL_MOUSEWHEEL:
             if (e.wheel.y < 0) // mousewheel down: rotate inventory
-                rotate_inventory(+1);
+                rotate_inventory(-1);
             if (e.wheel.y > 0) // mousewheel up: inverse rotate inventory
                 rotate_inventory(+1);
             break;


### PR DESCRIPTION
Scrolling the mousewheel in either direction erroneously rotated the inventory in the same way (this behavior was also contradicted by comments in the code).