### PR TITLE
Fix group subset construction with negativ indices

### DIFF
--- a/src/lua.cc
+++ b/src/lua.cc
@@ -3231,7 +3231,7 @@ static int subGroup(lua_State *L) {
     if (lua_gettop(L) == 2 && lua_isnumber(L, 2)) {
         end = lua_tointeger(L, 2);
         if (end < 0) {
-            start = length - end;
+            start = length - (-end);
             end = length;
         }
     }


### PR DESCRIPTION
Note:
  result = group:sub(number)

Should work for positive and negative numbers

// Refman 5.7.12

> With a number as argument you determine the number of requested objects.
> A positive number returns the amount of objects starting with the first object
> of the group. Whereas a negative number returns objects from the tail of the
> group.