### PR TITLE
Run autoupdate tool as suggested by output of autogen.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([enigma], [1.30], [enigma-devel@nongnu.org])
-AC_PREREQ(2.59)
+AC_INIT([enigma],[1.30],[enigma-devel@nongnu.org])
+AC_PREREQ([2.71])
 AC_CANONICAL_BUILD
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR([src/enigma.cc])
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([src/config.h])
-AC_GNU_SOURCE
+AC_USE_SYSTEM_EXTENSIONS
 
 ALL_LINGUAS="be bs cs da de el es fi fr gd hr hu it ja nl no pl pt ru sk sl sv uk zh"
 AC_SUBST(ALL_LINGUAS)

--- a/lib-src/enet/configure.ac
+++ b/lib-src/enet/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libenet], [1.0])
+AC_INIT([libenet],[1.0])
 AC_CONFIG_SRCDIR([callbacks.c])
 AM_INIT_AUTOMAKE
 
@@ -22,4 +22,5 @@ AC_CHECK_TYPE(socklen_t, [AC_DEFINE(HAS_SOCKLEN_T)], ,
 AC_EGREP_HEADER(MSG_MAXIOVLEN, /usr/include/sys/socket.h, AC_DEFINE(ENET_BUFFER_MAXIMUM, [MSG_MAXIOVLEN]))
 AC_EGREP_HEADER(MSG_MAXIOVLEN, socket.h, AC_DEFINE(ENET_BUFFER_MAXIMUM, [MSG_MAXIOVLEN]))
 
-AC_OUTPUT([Makefile include/Makefile include/enet/Makefile])
+AC_CONFIG_FILES([Makefile include/Makefile include/enet/Makefile])
+AC_OUTPUT

--- a/lib-src/zipios++/configure.ac
+++ b/lib-src/zipios++/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT([zipios++], [0.1.5])
+AC_INIT([zipios++],[0.1.5])
 AC_CONFIG_SRCDIR([src/backbuffer.h])
 AM_INIT_AUTOMAKE
 
@@ -49,7 +49,15 @@ dnl for symbols defined "manually" with AC_DEFINE
 AC_CHECK_LIB(z, zError, AC_DEFINE(HAVE_ZERROR, 1, [Define if zlib has zError]) )
 
 dnl Checks for header files.
-AC_HEADER_STDC
+m4_warn([obsolete],
+[The preprocessor macro `STDC_HEADERS' is obsolete.
+  Except in unusual embedded environments, you can safely include all
+  ISO C90 headers unconditionally.])dnl
+# Autoupdate added the next two lines to ensure that your configure
+# script's behavior did not change.  They are probably safe to remove.
+AC_CHECK_INCLUDES_DEFAULT
+AC_PROG_EGREP
+
 AC_CHECK_HEADERS(unistd.h)
 AC_CXX_HAVE_STL
 AC_CXX_HAVE_STD


### PR DESCRIPTION
With this patch, as suggested by autotools, there are even more warnings now :-/
I really don't know this whole autotools stack well enough to go ahead here.
Maybe we should switch to a more modern build system ...