### PR TITLE
fix esprit level 26 (bank-o-mat)

### DIFF
--- a/data/levels/enigma_esprit/esprit26_3.xml
+++ b/data/levels/enigma_esprit/esprit26_3.xml
@@ -20,7 +20,7 @@ ti["."] = {"it_seed"}
 ti["S"] = {"st_switch_black", target="get_money"}
 ti["G"] = {"st_lightglass"}
 ti["|"] = {"st_door", name="doors#", flavor="c"}
-ti["C"] = {"st_coinslot", interval_m=COIN_IGNORE, target="counter", action="signal"}
+ti["C"] = {"st_coinslot", interval_m=12, target="counter", action="signal"}
 ti["@"] = {"#ac_marble_black"}
 
 wo(ti, " ", {
@@ -42,12 +42,14 @@ wo:add({"ot_counter", "counter", state=0, target="doors#*", action_8="open"})
 
 local reserve = 8
 function get_money()
-    if reserve > 0 then
-        reserve = reserve -1
-        wo[po(16,1)] = {"it_coin_m"}
-    else
-        wo[po(16,1)] = {"it_document", text="text1"}
-    end
+	if not it(po(16,1)):exists() then
+		if reserve > 0 then
+			reserve = reserve -1
+			wo[po(16,1)] = {"it_coin_m"}
+		else
+			wo[po(16,1)] = {"it_document", text="text1"}
+		end
+	end
 end
  ]]></el:luamain>
     <el:i18n>

--- a/data/levels/enigma_esprit/esprit26_4.xml
+++ b/data/levels/enigma_esprit/esprit26_4.xml
@@ -3,7 +3,7 @@
   <el:protected>
     <el:info el:type="level">
       <el:identity el:title="Bank-O-Mat" el:subtitle="esprit 26" el:id="ss4"/>
-      <el:version el:score="3" el:release="3" el:revision="4" el:status="released"/>
+      <el:version el:score="4" el:release="4" el:revision="5" el:status="released"/>
       <el:author  el:name="Sven Siggelkow" el:email="" el:homepage=""/>
       <el:copyright>Copyright © 2003 Sven Siggelkow</el:copyright>
       <el:license el:type="GPL v2.0 or above" el:open="true"/>

--- a/data/levels/enigma_esprit/index.xml
+++ b/data/levels/enigma_esprit/index.xml
@@ -31,7 +31,7 @@
     <level _seq="23" _title="esprit 23" _xpath="./esprit23_2" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp23" rel="2" rev="1" score="1" target="time" unit="duration"/>
     <level _seq="24" _title="esprit 24" _xpath="./esprit24_1" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp24" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="25" _title="esprit 25" _xpath="./esprit25_2" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp25" rel="2" rev="1" score="1" target="time" unit="duration"/>
-    <level _seq="26" _title="Bank-O-Mat" _xpath="./esprit26_3" author="Sven Siggelkow" ctrl="force" easy="false" id="ss4" rel="3" rev="4" score="3" target="time" unit="duration"/>
+    <level _seq="26" _title="Bank-O-Mat" _xpath="./esprit26_4" author="Sven Siggelkow" ctrl="force" easy="false" id="ss4" rel="4" rev="5" score="3" target="time" unit="duration"/>
     <level _seq="27" _title="esprit 27" _xpath="./esprit27_1" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp27" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="28" _title="esprit 28" _xpath="./esprit28_1" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp28" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="29" _title="esprit 29" _xpath="./esprit29_1" author="Sven Siggelkow" ctrl="force" easy="false" id="ss_esp29" rel="1" rev="0" score="1" target="time" unit="duration"/>


### PR DESCRIPTION
With the coinslots being set to COIN_IGNORE, they would never trigger the door opening, rendering the level unsolvable.
I changed the interval to 12s, enough to insert all 8 coins necessary.

Furthermore, I added a safeguard such that the coin-generating switch does not delete objects on the ground where the coin appears.