### PR TITLE
Fix issue 88: Protect start position to prevent marble getting stuck

### DIFF
--- a/data/levels/enigma_cross/newlevels-0-92a.xml
+++ b/data/levels/enigma_cross/newlevels-0-92a.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <index xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd">
 
-  <info enigma="1.10" group="Facets" location="15100" network="false" owner="Enigma Team" release="1" revision="58" title="Enigma 0.92 - 1"/>
+  <info enigma="1.10" group="Facets" location="15100" network="false" owner="Enigma Team" release="1" revision="59" title="Enigma 0.92 - 1"/>
 
   <attributes/>
 
@@ -110,7 +110,7 @@
     <level _seq="102" _title="Come To Me" _xpath="enigma_ii/ant20_2" author="Petr Machata" ctrl="force" easy="false" id="ant20" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="103" _title="Corridors" _xpath="enigma_ii/siegfried29_1" author="Siegfried Fennig" ctrl="force" easy="false" id="level9f" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="104" _title="Dustwalkers" _xpath="enigma_ii/ant06_1" author="Petr Machata" ctrl="force" easy="false" id="ant06" rel="1" rev="0" score="1" target="time" unit="duration"/>
-    <level _seq="105" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="2" score="2" target="time" unit="duration"/>
+    <level _seq="105" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="3" score="2" target="time" unit="duration"/>
     <level _seq="106" _title="Everhungry" _xpath="enigma_iii/ant32_1" author="Petr Machata" ctrl="force" easy="false" id="ant32" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="107" _title="The Turtle" _xpath="enigma_iii/ant05_1" author="Petr Machata" ctrl="force" easy="false" id="ant05" rel="1" rev="1" score="1" target="time" unit="duration"/>
     <level _seq="108" _title="Grow Your Own" _xpath="enigma_iii/nat36_2" author="Nat Pryce" ctrl="force" easy="false" id="natmaze5" rel="2" rev="1" score="1" target="time" unit="duration"/>

--- a/data/levels/enigma_cross/tutorial-1-00.xml
+++ b/data/levels/enigma_cross/tutorial-1-00.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <index xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd">
 
-  <info enigma="1.10" group="Facets" location="15900" network="false" owner="Enigma Team" release="1" revision="42" title="Tutorial 1.00"/>
+  <info enigma="1.10" group="Facets" location="15900" network="false" owner="Enigma Team" release="1" revision="43" title="Tutorial 1.00"/>
 
   <attributes/>
 
@@ -52,7 +52,7 @@
     <level _seq="44" _title="Mission Impossible" _xpath="enigma_i/martin14_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin14" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="45" _title="Brittle Planks" _xpath="enigma_i/martin92_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin92" rel="2" rev="1" score="2" target="time" unit="duration"/>
     <level _seq="46" _title="Lasers 101" _xpath="enigma_i/daniel08_2" author="Daniel Heck" ctrl="force" easy="false" id="lasers101" rel="2" rev="1" score="1" target="time" unit="duration"/>
-    <level _seq="47" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="2" score="2" target="time" unit="duration"/>
+    <level _seq="47" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="3" score="2" target="time" unit="duration"/>
     <level _seq="48" _title="Brittle Floor!" _xpath="enigma_iii/martin91_1" author="Martin Hawlisch" ctrl="force" easy="true" id="martin91" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="49" _title="Inverted Laser Spiral" _xpath="enigma_ii/duffy42_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy42" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="50" _title="- Meditation -" _xpath="enigma_i/siegfried35_1" author="Siegfried Fennig" ctrl="force" easy="false" id="meditation14" rel="1" rev="1" score="1" target="time" unit="duration"/>

--- a/data/levels/enigma_ii/duffy03_2.xml
+++ b/data/levels/enigma_ii/duffy03_2.xml
@@ -3,7 +3,7 @@
   <el:protected>
     <el:info el:type="level">
       <el:identity el:title="Laser Spiral" el:subtitle="" el:id="duffy3"/>
-      <el:version el:score="2" el:release="2" el:revision="2" el:status="released"/>
+      <el:version el:score="2" el:release="2" el:revision="3" el:status="released"/>
       <el:author  el:name="Jacob Scott" el:email="" el:homepage=""/>
       <el:copyright>Copyright © 2003 Jacob Scott</el:copyright>
       <el:license el:type="GPL v2.0 or above" el:open="true"/>
@@ -21,7 +21,8 @@ ti["N"] = {"st_mirror_slab", orientation=WEST}
 ti["="] = {"st_mirror_slab", movable=true, orientation=EAST}
 ti["o"] = {"st_oxyd", name="upper#"}
 ti["O"] = {"st_oxyd", name="lower#"}
-ti["@"] = {"#ac_marble_black"}
+ti["X"] = {"st_grate"}
+ti["@"] = ti["X"] .. {"#ac_marble_black"}
 
 wo(ti, " ", {
     "##oooooo############",

--- a/data/levels/enigma_ii/index.xml
+++ b/data/levels/enigma_ii/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <index xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd">
 
-  <info enigma="1.10" group="Enigma" location="10300" network="false" owner="Enigma Team" release="1" revision="50" title="Enigma II"/>
+  <info enigma="1.10" group="Enigma" location="10300" network="false" owner="Enigma Team" release="1" revision="51" title="Enigma II"/>
 
   <attributes/>
 
@@ -79,7 +79,7 @@
     <level _seq="71" _title="Come To Me" _xpath="./ant20_2" author="Petr Machata" ctrl="force" easy="false" id="ant20" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="72" _title="Water Holes" _xpath="./siegfried10_2" author="Siegfried Fennig" ctrl="force" easy="false" id="level3f" rel="2" rev="1" score="1" target="time" unit="duration"/>
     <level _seq="73" _title="Follow the Leader" _xpath="./martin71_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin71" rel="2" rev="4" score="2" target="time" unit="duration"/>
-    <level _seq="74" _title="Laser Spiral" _xpath="./duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="2" score="2" target="time" unit="duration"/>
+    <level _seq="74" _title="Laser Spiral" _xpath="./duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="3" score="2" target="time" unit="duration"/>
     <level _seq="75" _title="Puzzle Blues" _xpath="./siegfried07_2" author="Siegfried Fennig" ctrl="force" easy="false" id="level3c" rel="2" rev="1" score="1" target="time" unit="duration"/>
     <level _seq="76" _title="Pools" _xpath="./martin70_2" author="Martin Hawlisch" ctrl="force" easy="false" id="martin70" rel="2" rev="1" score="1" target="time" unit="duration"/>
     <level _seq="77" _title="Push your way" _xpath="./siegfried12_2" author="Siegfried Fennig" ctrl="force" easy="false" id="level4b" rel="2" rev="1" score="1" target="time" unit="duration"/>

--- a/data/levels/tutorial_basic/index.xml
+++ b/data/levels/tutorial_basic/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <index xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd">
 
-  <info enigma="1.10" group="Tutorials" location="10120" network="false" owner="Enigma Team" release="1" revision="42" title="Basic Tutorial"/>
+  <info enigma="1.10" group="Tutorials" location="10120" network="false" owner="Enigma Team" release="1" revision="43" title="Basic Tutorial"/>
 
   <attributes/>
 
@@ -52,7 +52,7 @@
     <level _seq="44" _title="Mission Impossible" _xpath="enigma_i/martin14_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin14" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="45" _title="Brittle Planks" _xpath="enigma_i/martin92_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin92" rel="2" rev="1" score="2" target="time" unit="duration"/>
     <level _seq="46" _title="Lasers 101" _xpath="enigma_i/daniel08_2" author="Daniel Heck" ctrl="force" easy="false" id="lasers101" rel="2" rev="1" score="1" target="time" unit="duration"/>
-    <level _seq="47" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="2" score="2" target="time" unit="duration"/>
+    <level _seq="47" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="3" score="2" target="time" unit="duration"/>
     <level _seq="48" _title="Brittle Floor!" _xpath="enigma_iii/martin91_1" author="Martin Hawlisch" ctrl="force" easy="true" id="martin91" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="49" _title="Inverted Laser Spiral" _xpath="enigma_ii/duffy42_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy42" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="50" _title="- Meditation -" _xpath="enigma_i/siegfried35_1" author="Siegfried Fennig" ctrl="force" easy="false" id="meditation14" rel="1" rev="1" score="1" target="time" unit="duration"/>

--- a/data/levels/tutorial_old/index.xml
+++ b/data/levels/tutorial_old/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <index xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="index.xsd">
 
-  <info enigma="1.10" group="Tutorials" location="10130" network="false" owner="Enigma Team" release="1" revision="44" title="Tutorial"/>
+  <info enigma="1.10" group="Tutorials" location="10130" network="false" owner="Enigma Team" release="1" revision="45" title="Tutorial"/>
 
   <attributes/>
 
@@ -53,7 +53,7 @@
     <level _seq="45" _title="Mission Impossible" _xpath="enigma_i/martin14_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin14" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="46" _title="Brittle Planks" _xpath="enigma_i/martin92_2" author="Martin Hawlisch" ctrl="force" easy="true" id="martin92" rel="2" rev="1" score="2" target="time" unit="duration"/>
     <level _seq="47" _title="Lasers 101" _xpath="enigma_i/daniel08_2" author="Daniel Heck" ctrl="force" easy="false" id="lasers101" rel="2" rev="1" score="1" target="time" unit="duration"/>
-    <level _seq="48" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="2" score="2" target="time" unit="duration"/>
+    <level _seq="48" _title="Laser Spiral" _xpath="enigma_ii/duffy03_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy3" rel="2" rev="3" score="2" target="time" unit="duration"/>
     <level _seq="49" _title="Brittle Floor!" _xpath="enigma_iii/martin91_1" author="Martin Hawlisch" ctrl="force" easy="true" id="martin91" rel="1" rev="0" score="1" target="time" unit="duration"/>
     <level _seq="50" _title="Inverted Laser Spiral" _xpath="enigma_ii/duffy42_2" author="Jacob Scott" ctrl="force" easy="false" id="duffy42" rel="2" rev="2" score="2" target="time" unit="duration"/>
     <level _seq="51" _title="- Meditation -" _xpath="enigma_i/siegfried35_1" author="Siegfried Fennig" ctrl="force" easy="false" id="meditation14" rel="1" rev="1" score="1" target="time" unit="duration"/>


### PR DESCRIPTION
Fixes Issue #88 

If this is to much of a "spoiler", we can also move the start position to (1,1) where it is less likely to get stuck.