### PR TITLE
etc/enigma.desktop: use standard-specified Categories

### DIFF
--- a/etc/enigma.desktop
+++ b/etc/enigma.desktop
@@ -44,5 +44,4 @@ Terminal=false
 StartupNotify=false
 Icon=enigma
 Type=Application
-X-Categories=Application;Game;PuzzleGame;
-
+Categories=Game;LogicGame;


### PR DESCRIPTION
Application's Categories listed in the *.desktop file should follow the Freedesktop specification. Categories fitting Enigma are:
 Game - main category for "A game" [1]
 LogicGame - additional category for "Logic games like puzzles, etc" [2]

With standard categories, there is no need for extensions ("X-"). "desktop-file-validate etc/enigma.desktop" is happy.

[1] https://specifications.freedesktop.org/menu-spec/latest/category-registry.html
[2] https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html

Fixes: 0db9df0aea0c ("Fix .desktop to success the desktop-filde-validate")