### PR TITLE
Fix memory leaks

### DIFF
--- a/lib-src/enigma-core/ecl_video.cc
+++ b/lib-src/enigma-core/ecl_video.cc
@@ -367,16 +367,16 @@ ecl::Screen *ecl::Screen::get_instance() {
 
 ecl::Screen::Screen(SDL_Window *window, int surface_w, int surface_h)
 : m_window(window),
-  m_surface(Surface::make_surface(
-      SDL_CreateRGBSurface(0, surface_w, surface_h, 32, 0xff0000, 0xff00, 0xff, 0xff000000),
-      NO_ALPHA)),
-  m_sdlsurface(m_surface->get_surface()),
   update_all_p(false) {
+    m_surface.reset(Surface::make_surface(
+        SDL_CreateRGBSurface(0, surface_w, surface_h, 32, 0xff0000, 0xff00, 0xff, 0xff000000),
+        NO_ALPHA));
+    m_sdlsurface = m_surface->get_surface();
     assert(m_window);
     assert(m_surface);
     assert(m_instance == 0);
     m_instance = this;
-    m_scaler = new ecl::Scaler(m_surface->get_surface(), NULL, SDL_GetWindowSurface(m_window));
+    m_scaler = std::make_unique<ecl::Scaler>(m_surface->get_surface(), nullptr, SDL_GetWindowSurface(m_window));
 }
 
 ecl::Screen::~Screen() {
@@ -750,6 +750,6 @@ Surface *ecl::MakeSurface(void *data, int w, int h, int bipp, int pitch, const R
 }
 
 void ecl::BlitScaled(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect, ScalerMode mode) {
-    Scaler* scaler = new Scaler(src, srcrect, dst, mode);
-    scaler->blit_scaled(src, srcrect, dst, dstrect);
+    Scaler scaler{src, srcrect, dst, mode};
+    scaler.blit_scaled(src, srcrect, dst, dstrect);
 }

--- a/lib-src/enigma-core/ecl_video.hh
+++ b/lib-src/enigma-core/ecl_video.hh
@@ -20,6 +20,7 @@
 #define ECL_VIDEO_HH_INCLUDED
 
 #include "ecl_geom.hh"
+#include <memory>
 
 #include "SDL.h"
 
@@ -248,7 +249,7 @@ public:
     /* ---------- Accessors ---------- */
 
     SDL_Window *window() const { return m_window; }
-    Surface *get_surface() const { return m_surface; }
+    Surface *get_surface() const { return m_surface.get(); }
 
     Rect size() const;
     int width() const;
@@ -267,7 +268,7 @@ private:
     static Screen *m_instance;
 
     SDL_Window *m_window;
-    Surface *m_surface;
+    std::unique_ptr<Surface> m_surface;
     SDL_Surface *m_sdlsurface;
     RectList m_dirtyrects;
     bool update_all_p;
@@ -275,7 +276,7 @@ private:
     Screen(const Screen &);
     Screen &operator=(const Screen &);
 
-    Scaler *m_scaler;
+    std::unique_ptr<Scaler> m_scaler;
 };
 
 /* -------------------- Graphics primitives -------------------- */

--- a/src/gui/InfoMenu.cc
+++ b/src/gui/InfoMenu.cc
@@ -55,11 +55,11 @@ namespace enigma { namespace gui {
         numPages = process_infotext(false);
 
         but_ok   = new StaticTextButton(N_("Ok"), this);
-        pgup     = new ImageButton("ic-up", "ic-up1", this);
-        pgdown   = new ImageButton("ic-down", "ic-down1", this);
 
         add(but_ok, Rect(vminfo.width-(vshrink?80:130), vminfo.height-(vshrink?30:60), vshrink?70:110, vshrink?20:40));
         if (numPages > pInfo[vminfo.tt].columnsPerPage) {
+            pgup     = new ImageButton("ic-up", "ic-up1", this);
+            pgdown   = new ImageButton("ic-down", "ic-down1", this);
             add(pgup, Rect(vminfo.width-(vshrink?15:30), vminfo.height/2, vshrink?10:20, vshrink?25:50));
             add(pgdown, Rect(vminfo.width-(vshrink?15:30), vminfo.height/2 +(vshrink?35:70), vshrink?10:20, vshrink?25:50));
         }
@@ -119,12 +119,12 @@ namespace enigma { namespace gui {
     void InfoMenu::on_action (gui::Widget *w) {
         if (w == but_ok) {
             Menu::quit();
-        } else if (w == pgup) {
+        } else if (pgup && w == pgup) {
             if (curPage > 0) {
                 curPage--;
                 invalidate_all();
             }
-        } else if (w == pgdown) {
+        } else if (pgdown && w == pgdown) {
             if (curPage < numPages - 1) {
                 curPage++;
                 invalidate_all();

--- a/src/gui/InfoMenu.hh
+++ b/src/gui/InfoMenu.hh
@@ -32,9 +32,9 @@ namespace enigma { namespace gui {
         const char **info;
         int          curPage;
         int          numPages;
-        Widget      *but_ok;
-        Widget      *pgup;
-        Widget      *pgdown;
+        Widget      *but_ok = nullptr;
+        Widget      *pgup = nullptr;
+        Widget      *pgdown = nullptr;
         ecl::GC     *current_gc;
 
         int process_infotext(bool render);

--- a/src/gui/LevelPackMenu.cc
+++ b/src/gui/LevelPackMenu.cc
@@ -183,13 +183,16 @@ namespace enigma { namespace gui {
         }
         if (but_tutorial2 != NULL) {
             remove_child(but_tutorial2);
-            delete but_tutorial1;
+            delete but_tutorial2;
             but_tutorial2 = NULL;
         }
 
-        for (auto it = tutorialLines.begin(); it != tutorialLines.end(); it++)
-            if (*it != NULL)
+        for (auto it = tutorialLines.begin(); it != tutorialLines.end(); it++) {
+            if (*it != NULL) {
                 remove_child(*it);
+                delete *it;
+            }
+        }
         tutorialLines.clear();
 
         packButtons.clear();

--- a/src/lev/PersistentIndex.hh
+++ b/src/lev/PersistentIndex.hh
@@ -51,6 +51,7 @@ namespace enigma { namespace lev {
     class PersistentIndex : public Index  {
     public:
         static void registerPersistentIndices(bool onlySystemIndices);
+        static void registerIndex(std::unique_ptr<PersistentIndex> index);
         static PersistentIndex * historyIndex;
         static void addCurrentToHistory();
         static void shutdown();
@@ -127,6 +128,7 @@ namespace enigma { namespace lev {
         std::string indexUrl;
     private:
         static std::vector<std::shared_ptr<PersistentIndex> > indexCandidates;
+        static std::vector<std::unique_ptr<PersistentIndex> > persistentIndices;
         std::string absIndexPath;
         XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument *doc;
         XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *infoElem;

--- a/src/stones/ShogunStone.cc
+++ b/src/stones/ShogunStone.cc
@@ -23,7 +23,8 @@
 #include "world.hh"
 
 namespace enigma {
-    ShogunStone::ShogunStone(int holes) : Stone () {
+    ShogunStone::ShogunStone(int holes) :
+            Stone (), subShogun(nullptr), superShogun(nullptr) {
         objFlags |= holes << 24;
     }
 


### PR DESCRIPTION
This PR fixes 4 memory leaks and one segfault.

Enigma version: 1.30-182-g2642663f

<details>

<summary> System information </summary>

Compiler: Clang 19.1.7
Compilation flags: `(export CC=clang CXX=clang++ CFLAGS='-O3 -ffast-math -fno-finite-math-only -g -fno-omit-frame-pointer -mtune=skylake -fsanitize=address,undefined' CXXFLAGS="$CFLAGS" LDFLAGS=-fsanitize=address,undefined;time ./configure && time make -j6)`
Windows Subsystem for Linux distro: openSUSE 16.0
WSL version: 2.6.3.0
Kernel version: 6.6.87.2-1
WSLg version: 1.0.71
MSRDC version: 1.2.6353
Direct3D version: 1.611.1-81528511
DXCore version: 10.0.26100.1-240331-1435.ge-release
Windows version: 10.0.19045.6809

Hardware: MSI GS63 Stealth 8RE
• 8th gen Intel Core i7-8750h "Skylake"
• 32GB DDR4 RAM
• Nvidia GeForce GTX 1060 (6GB)
• Integrated Intel UHD 630
• 256 GB C:, 2TB D: and E: drives

</details>

The first memory leak I fixed with this PR is a 2MB leak of Scaler objects. Scaler objects are made in _Screen::Screen()_ and _ecl::BlitScaled()_ but not deallocated, and each one leaks about 2 or 3 megabytes. I fixed this by using `unique_ptr`s.

The second leak was a very small (<1 KB) that happens when opening the Level Pack menu. Buttons and widgets were not being deallocated properly. `but_tutorial1` was deleted in two places where `but_tutorial2` should have been deleted, and `tutorialLines` widgets were removed but not deleted. Used plain delete here because I didn't want to refactor the widget deallocation code in the base class.

Third commit fixes a segfault due to not initializing a pointer.

Fourth commit fixes leaking persistent indices using `unique_ptr`s (less than 1 KB, I think)

Fifth commit fixes a small (320 byte) leak in the Help menu when viewing the game's paths.

There is another problem in the game where it deletes `SubProxy`s using the base `Proxy` pointer, but making `Proxy` destructor virtual does not work right due to the sized `delete` in C++14 (SubProxy and Proxy have different sizes), and Proxy's constructor/destructor are protected, so I can't use `unique_ptr` there. That should be a separate issue, through.

<details>

<summary> 1) Scaler leak </summary>

```c++
Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x5fbcb7df1e28 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x5fbcb805a33b in ecl::Surface::make_surface(SDL_Surface*, bool) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:353:12
    #2 0x5fbcb805a47b in ecl::Screen::Screen(SDL_Window*, int, int) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:370:13
    #3 0x5fbcb7ec055a in enigma::VideoEngineImpl::OpenWindow(int, int, bool) /home/nathan/src/Enigma/src/video.cc:773:18
    #4 0x5fbcb7ebfdc4 in enigma::VideoEngineImpl::Init() /home/nathan/src/Enigma/src/video.cc:468:19
    #5 0x5fbcb7ec1e59 in enigma::VideoInit() /home/nathan/src/Enigma/src/video.cc:900:19
    #6 0x5fbcb7e5d18d in enigma::Application::init(int, char**) /home/nathan/src/Enigma/src/main.cc:430:5
    #7 0x5fbcb7e6222a in main /home/nathan/src/Enigma/src/main.cc:992:13
    #8 0x7486c1e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
    
Indirect leak of 3204 byte(s) in 1 object(s) allocated from:
    #0 0x5fbcb7db0497 in malloc /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x5fbcb805b6d3 in ecl::Scaler::precalculate(SDL_Surface*, SDL_Rect*, SDL_Surface*) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:488:24
    #2 0x5fbcb805bb0d in ecl::Scaler::Scaler(SDL_Surface*, SDL_Rect*, SDL_Surface*, ecl::ScalerMode) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:466:5
    #3 0x5fbcb805a585 in ecl::Screen::Screen(SDL_Window*, int, int) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:379:20
    #4 0x5fbcb7ec055a in enigma::VideoEngineImpl::OpenWindow(int, int, bool) /home/nathan/src/Enigma/src/video.cc:773:18
    #5 0x5fbcb7ebfdc4 in enigma::VideoEngineImpl::Init() /home/nathan/src/Enigma/src/video.cc:468:19
    #6 0x5fbcb7ec1e59 in enigma::VideoInit() /home/nathan/src/Enigma/src/video.cc:900:19
    #7 0x5fbcb7e5d18d in enigma::Application::init(int, char**) /home/nathan/src/Enigma/src/main.cc:430:5
    #8 0x5fbcb7e6222a in main /home/nathan/src/Enigma/src/main.cc:992:13
    #9 0x7486c1e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)

Indirect leak of 2404 byte(s) in 1 object(s) allocated from:
    #0 0x5fbcb7db0497 in malloc /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x5fbcb805b720 in ecl::Scaler::precalculate(SDL_Surface*, SDL_Rect*, SDL_Surface*) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:493:24
    #2 0x5fbcb805bb0d in ecl::Scaler::Scaler(SDL_Surface*, SDL_Rect*, SDL_Surface*, ecl::ScalerMode) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:466:5
    #3 0x5fbcb805a585 in ecl::Screen::Screen(SDL_Window*, int, int) /home/nathan/src/Enigma/lib-src/enigma-core/ecl_video.cc:379:20
    #4 0x5fbcb7ec055a in enigma::VideoEngineImpl::OpenWindow(int, int, bool) /home/nathan/src/Enigma/src/video.cc:773:18
    #5 0x5fbcb7ebfdc4 in enigma::VideoEngineImpl::Init() /home/nathan/src/Enigma/src/video.cc:468:19
    #6 0x5fbcb7ec1e59 in enigma::VideoInit() /home/nathan/src/Enigma/src/video.cc:900:19
    #7 0x5fbcb7e5d18d in enigma::Application::init(int, char**) /home/nathan/src/Enigma/src/main.cc:430:5
    #8 0x5fbcb7e6222a in main /home/nathan/src/Enigma/src/main.cc:992:13
    #9 0x7486c1e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
```

</details>

<details>

<summary> 2) LevelPackMenu/UntranslatedLabel leak </summary>

```c++
Direct leak of 512 byte(s) in 4 object(s) allocated from:
    #0 0x5bc7f6418e28 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x5bc7f65519ef in enigma::gui::LevelPackMenu::setupMenu() /home/nathan/src/Enigma/src/gui/LevelPackMenu.cc:296:34
    #2 0x5bc7f6553118 in enigma::gui::LevelPackMenu::manage() /home/nathan/src/Enigma/src/gui/LevelPackMenu.cc:465:9
    #3 0x5bc7f65530cd in enigma::gui::LevelPackMenu::manageLevelMenu() /home/nathan/src/Enigma/src/gui/LevelPackMenu.cc:454:27
    #4 0x5bc7f6565989 in enigma::gui::MainMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:527:15
    #5 0x5bc7f657be98 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #6 0x5bc7f657f025 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #7 0x5bc7f65665aa in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #8 0x5bc7f6566272 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #9 0x5bc7f6565d69 in enigma::gui::ShowMainMenu() /home/nathan/src/Enigma/src/gui/MainMenu.cc:577:11
    #10 0x5bc7f648924b in main /home/nathan/src/Enigma/src/main.cc:994:13
    #11 0x7baa86e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
```

</details>

<details>

<summary> 3) PersistentIndex leak </summary>

```c++

Direct leak of 424 byte(s) in 1 object(s) allocated from:
    #0 0x5fbcb7df1e28 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x5fbcb7f9d7ce in enigma::lev::PersistentIndex::registerPersistentIndices(bool) /home/nathan/src/Enigma/src/lev/PersistentIndex.cc:224:39
    #2 0x5fbcb7e5d5a8 in enigma::Application::init(int, char**) /home/nathan/src/Enigma/src/main.cc:458:5
    #3 0x5fbcb7e6222a in main /home/nathan/src/Enigma/src/main.cc:992:13
    #4 0x7486c1e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)

Indirect leak of 35 byte(s) in 1 object(s) allocated from:
    #0 0x5fbcb7df1e28 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x5fbcb7df787c in std::__new_allocator<char>::allocate(unsigned long, void const*) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/new_allocator.h:151:27
    #2 0x5fbcb7df77d0 in std::allocator_traits<std::allocator<char>>::allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/alloc_traits.h:614:20
    #3 0x5fbcb7df77d0 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/basic_string.h:142:16
    #4 0x5fbcb7df7602 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_create(unsigned long&, unsigned long) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/basic_string.tcc:164:14
    #5 0x5fbcb7df7d53 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<true>(char const*, unsigned long) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/basic_string.tcc:291:12
    #6 0x5fbcb7df7bef in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/bin/../lib64/gcc/x86_64-suse-linux/15/../../../../include/c++/15/bits/basic_string.h:617:2
    #7 0x5fbcb7f87fc8 in enigma::lev::Index::Index(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, double) /home/nathan/src/Enigma/src/lev/Index.cc:424:38
    #8 0x5fbcb7fa053d in enigma::lev::PersistentIndex::PersistentIndex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, bool, bool, bool, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /home/nathan/src/Enigma/src/lev/PersistentIndex.cc:343:13
    #9 0x5fbcb7f9d914 in enigma::lev::PersistentIndex::registerPersistentIndices(bool) /home/nathan/src/Enigma/src/lev/PersistentIndex.cc:224:43
    #10 0x5fbcb7e5d5a8 in enigma::Application::init(int, char**) /home/nathan/src/Enigma/src/main.cc:458:5
    #11 0x5fbcb7e6222a in main /home/nathan/src/Enigma/src/main.cc:992:13
    #12 0x7486c1e3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
```

</details>

<details>

<summary> 4) InfoMenu leak </summary>

```c++
Direct leak of 160 byte(s) in 1 object(s) allocated from:
    #0 0x60da86beae58 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x60da86cfcbe5 in enigma::gui::InfoMenu::InfoMenu(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:58:20
    #2 0x60da86cfdaef in enigma::gui::displayInfo(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:137:18
    #3 0x60da86d36027 in enigma::gui::MainHelpMenu::showPaths() /home/nathan/src/Enigma/src/gui/MainMenu.cc:428:9
    #4 0x60da86d34fc1 in enigma::gui::MainHelpMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:335:13
    #5 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #6 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #7 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #8 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #9 0x60da86d37c95 in enigma::gui::MainMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:553:15
    #10 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #11 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #12 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #13 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #14 0x60da86d37dd9 in enigma::gui::ShowMainMenu() /home/nathan/src/Enigma/src/gui/MainMenu.cc:577:11
    #15 0x60da86c5b27b in main /home/nathan/src/Enigma/src/main.cc:994:13
    #16 0x79dabaa3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
Direct leak of 160 byte(s) in 1 object(s) allocated from:
    #0 0x60da86beae58 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x60da86cfccda in enigma::gui::InfoMenu::InfoMenu(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:59:20
    #2 0x60da86cfdaef in enigma::gui::displayInfo(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:137:18
    #3 0x60da86d36027 in enigma::gui::MainHelpMenu::showPaths() /home/nathan/src/Enigma/src/gui/MainMenu.cc:428:9
    #4 0x60da86d34fc1 in enigma::gui::MainHelpMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:335:13
    #5 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #6 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #7 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #8 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #9 0x60da86d37c95 in enigma::gui::MainMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:553:15
    #10 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #11 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #12 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #13 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #14 0x60da86d37dd9 in enigma::gui::ShowMainMenu() /home/nathan/src/Enigma/src/gui/MainMenu.cc:577:11
    #15 0x60da86c5b27b in main /home/nathan/src/Enigma/src/main.cc:994:13
    #16 0x79dabaa3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
    
Direct leak of 160 byte(s) in 1 object(s) allocated from:
    #0 0x60da86beae58 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x60da86cfccda in enigma::gui::InfoMenu::InfoMenu(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:59:20
    #2 0x60da86cfdaef in enigma::gui::displayInfo(char const**) /home/nathan/src/Enigma/src/gui/InfoMenu.cc:137:18
    #3 0x60da86d36027 in enigma::gui::MainHelpMenu::showPaths() /home/nathan/src/Enigma/src/gui/MainMenu.cc:428:9
    #4 0x60da86d34fc1 in enigma::gui::MainHelpMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:335:13
    #5 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #6 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #7 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #8 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #9 0x60da86d37c95 in enigma::gui::MainMenu::on_action(enigma::gui::Widget*) /home/nathan/src/Enigma/src/gui/MainMenu.cc:553:15
    #10 0x60da86d4df08 in enigma::gui::Widget::invoke_listener() /home/nathan/src/Enigma/src/gui/widgets.cc:63:21
    #11 0x60da86d51095 in enigma::gui::PushButton::on_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/widgets.cc:764:13
    #12 0x60da86d3861a in enigma::gui::Menu::handle_event(SDL_Event const&) /home/nathan/src/Enigma/src/gui/Menu.cc:169:45
    #13 0x60da86d382e2 in enigma::gui::Menu::manage() /home/nathan/src/Enigma/src/gui/Menu.cc:96:17
    #14 0x60da86d37dd9 in enigma::gui::ShowMainMenu() /home/nathan/src/Enigma/src/gui/MainMenu.cc:577:11
    #15 0x60da86c5b27b in main /home/nathan/src/Enigma/src/main.cc:994:13
    #16 0x79dabaa3033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 41d443e8a12973d20e705f4efb33ee3bed03f727)
```

</details>