### PR TITLE
Fix CXXLUA CFLAGS conflict with C23 on macOS

### DIFF
--- a/lib-src/lua/Makefile.am
+++ b/lib-src/lua/Makefile.am
@@ -25,5 +25,5 @@ liblua_a_CFLAGS += -DLUA_USE_LINUX
 endif
 
 if CXXLUA
-liblua_a_CFLAGS += -x c++ $(AM_CXXFLAGS) $(CXXFLAGS)
+liblua_a_CFLAGS = -x c++ $(AM_CXXFLAGS) $(CXXFLAGS)
 endif

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -21,5 +21,5 @@ tolua_CFLAGS = -I$(top_srcdir)/lib-src/lua $(AM_CFLAGS)
 tolua_LDADD = $(top_builddir)/lib-src/lua/liblua.a $(AM_LDADD)
 
 if CXXLUA
-tolua_CFLAGS += -x c++ $(AM_CXXFLAGS) $(CXXFLAGS)
+tolua_CFLAGS = -I$(top_srcdir)/lib-src/lua -x c++ $(AM_CXXFLAGS) $(CXXFLAGS)
 endif


### PR DESCRIPTION
Allows Building on Apple Silicon / Latest MacOS.

When CXXLUA is enabled, the C standard flag -std=gnu23 was being passed to C++ compilation via -x c++, causing build failures. Override CFLAGS instead of appending to avoid inheriting the C standard flag.