### PR TITLE
Fix compilation on modern Linux systems

### DIFF
--- a/lib-src/enigma-core/ecl_cache.hh
+++ b/lib-src/enigma-core/ecl_cache.hh
@@ -20,6 +20,7 @@
 #define ECL_CACHE_HH
 
 #include <unordered_map>
+#include <memory>
 
 namespace ecl {
 

--- a/lib-src/enigma-core/ecl_font.hh
+++ b/lib-src/enigma-core/ecl_font.hh
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace ecl {
 

--- a/lib-src/enigma-core/ecl_system.hh
+++ b/lib-src/enigma-core/ecl_system.hh
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <set>
+#include <ctime>
 
 namespace ecl {
 

--- a/lib-src/enigma-core/ecl_video.hh
+++ b/lib-src/enigma-core/ecl_video.hh
@@ -20,6 +20,7 @@
 #define ECL_VIDEO_HH_INCLUDED
 
 #include "ecl_geom.hh"
+#include <memory>
 
 #include "SDL.h"
 

--- a/src/Utf8ToXML.cc
+++ b/src/Utf8ToXML.cc
@@ -21,6 +21,7 @@
 
 #include "main.hh"
 
+#include <cstring>
 #include <xercesc/util/TransService.hpp>
 #include <xercesc/util/XMLString.hpp>
 

--- a/src/d_models.cc
+++ b/src/d_models.cc
@@ -27,6 +27,7 @@
 #include "video.hh"
 
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 
 #ifndef CXXLUA

--- a/src/file.cc
+++ b/src/file.cc
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <ios>
 #include <sstream>
+#include <cstring>
 
 using namespace ecl;
 

--- a/src/video.cc
+++ b/src/video.cc
@@ -490,7 +490,7 @@ void VideoEngineImpl::Init() {
     UpdateBrightness();
 // Mac icon is set via Makefile
 #ifndef MACOSX
-    if (Surface *icon = enigma::GetImage("enigma_marble")) {
+    if (ecl::Surface *icon = enigma::GetImage("enigma_marble")) {
         SDL_SetWindowIcon(window, icon->get_surface());
     }
 #endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(tolua tolua.c toluabind.c toluabind.h)
-target_link_libraries(tolua lua)
+target_link_libraries(tolua lua m)
 


### PR DESCRIPTION
I was trying to compile the master branch on Ubuntu 24.04 and GCC 13, and I got a bunch of missing include or library errors. This PR makes it compile properly on modern systems. For reference, in case it helps anyone, here are compilation instructions for Ubuntu 22.04/24.04:

```
apt-get update && apt-get install -y build-essential cmake automake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libxerces-c-dev libenet-dev xdg-utils libpng-dev zlib1g-dev git gettext libcurl4-openssl-dev
git clone https://github.com/unrealtournament/Enigma
cd Enigma

mkdir build && cd build
cmake ..
make
```

You could also compile this on a Docker container and then copy it to the host, the libraries required (on the host) to run it are:

```
sudo apt-get update && sudo apt-get install -y fonts-dejavu-extra libenet7 libfluidsynth3 libinstpatch-1.0-2 libmodplug1 libopusfile0 libsdl2-image-2.0-0 libsdl2-mixer-2.0-0 fluid-soundfont-gm libsdl2-2.0-0 libsdl2-ttf-2.0-0 libxerces-c3.2t64
```

To run it afterwards, make sure to pass the proper parameters (this assumes current directory as the repo base dir):
```
./build/src/enigma --data data/ --l10n data/locale/
```